### PR TITLE
fix: harden integration smoke step

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,6 @@ jobs:
 
       - name: Smoke upload parser index search
         run: |
-          set -euo pipefail
           echo "hello from ci" > /tmp/test.txt
           curl -fsS -F "files=@/tmp/test.txt" http://localhost/ingest/upload || {
             docker compose -f infra/docker-compose.yml logs ingest gateway || true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Smoke upload parser index search
         run: |
-          set -e
+          set -euo pipefail
           echo "hello from ci" > /tmp/test.txt
           curl -fsS -F "files=@/tmp/test.txt" http://localhost/ingest/upload || {
             docker compose -f infra/docker-compose.yml logs ingest gateway || true


### PR DESCRIPTION
## Summary
- ensure the integration smoke test fails fast on unset variables or pipe errors by enabling `set -euo pipefail`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb8cd8ec88832ab6eefad3c1def5bf